### PR TITLE
Force update installed dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN ln -fs /usr/bin/python${v} /usr/bin/python3 && \
   apt purge -y && \
   rm -rf /root/.pip/cache/* /tmp/pip*
 
+# Update outdated installed packages and requirements
+RUN pip3 list -o 2>/dev/null | sed -n '3,${s/\s.*$//p}' | xargs -n 1 pip3 install -U  || true
 RUN python$version -m pip install --user -r /usr/bin/redsift/requirements.txt
 
 RUN chown -R sandbox:sandbox $HOME


### PR DESCRIPTION
Force update installed dependencies.

Run uses `site.addsitedir` which appends to `sys.path`. If we have an outdated library already installed will generate a conflict, and select the outdated one that appears first on the list.